### PR TITLE
Fix docs rendering

### DIFF
--- a/src/Elm/Case.elm
+++ b/src/Elm/Case.elm
@@ -407,10 +407,7 @@ branch name exp =
         exp
 
 
-{-|
-
-    A catchall branch in case you want the case to be nonexhaustive.
-
+{-| A catchall branch in case you want the case to be nonexhaustive.
 -}
 otherwise : (Expression -> Expression) -> Branch
 otherwise toExp =


### PR DESCRIPTION
The links being indented made it be rendered like a code block.

There is a similar problem for https://elm-doc-preview.netlify.app/Elm?repo=mdgriffith%2Felm-codegen&version=master#functionAdvanced