### PR TITLE
Handle Elm generator init error (bad flags)

### DIFF
--- a/cli/run.ts
+++ b/cli/run.ts
@@ -64,8 +64,14 @@ async function run_generator(base: string, moduleName: string, elm_source: strin
     })
     .catch((errors) => {
       let formatted = ""
-      for (const err of errors) {
-        formatted = formatted + format_title(err.title) + "\n\n" + err.description + "\n"
+
+      if (!!errors[Symbol.iterator]) {
+        for (const err of errors) {
+          formatted = formatted + format_title(err.title) + "\n\n" + err.description + "\n"
+        }
+      }
+      else {
+        formatted = `Error in ${moduleName}\n\n` + chalk.cyan(errors.message) + `\n\n\nAdd the ${chalk.cyan("--debug")} flag to see details.` // Assuming this is an Elm init error.
       }
       console.error(formatted)
     })


### PR DESCRIPTION
When passing incorrect flags to the generator Elm init errors do not appear.

In `Generate.elm`:
```
main : Program { test : String } () ()
```

In CLI:
```
> elm-codegen run --flags='{"test":1}'


```

This PR proposes to fix that by assuming if the error is not an iterable, then it is an [Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error) object which Elm throws when the app is initialized with bad flags.

Here's the proposed error message:
![image](https://user-images.githubusercontent.com/289969/152913641-7b11d778-6591-46c5-af37-891bdd04cd4a.png)

With `--debug`:
![image](https://user-images.githubusercontent.com/289969/152913737-9c640dea-6dce-46a2-be6b-7671e9bd2b77.png)

I could pass in the debug argument to hide the "Add the --debug flag to see details." message if the flag is already included.

I'm not entirely happy with "Error in Generate". I thought about "Error in Elm.Generate.init" or "Error in Generate.elm". Thoughts?

