### PR TITLE
fix uniqueness of generics in type alias signatures

### DIFF
--- a/src/Internal/Compiler.elm
+++ b/src/Internal/Compiler.elm
@@ -141,9 +141,7 @@ formatAliasKey mod name =
 addAlias : List String -> String -> Annotation -> AliasCache -> AliasCache
 addAlias mod name ((Annotation annDetails) as ann) aliasCache =
     Dict.insert (formatAliasKey mod name)
-        { variables =
-            getGenerics ann
-                |> unique
+        { variables = getGenerics ann
         , target = annDetails.annotation
         }
         aliasCache
@@ -705,6 +703,7 @@ inferenceErrorToString inf =
 getGenerics : Annotation -> List String
 getGenerics (Annotation details) =
     getGenericsHelper details.annotation
+        |> unique
 
 
 getGenericsHelper : Annotation.TypeAnnotation -> List String

--- a/tests/TypeChecking.elm
+++ b/tests/TypeChecking.elm
@@ -205,6 +205,17 @@ map fn optional =
                     (String.trim """
 (a -> fn_result) -> Optional a -> Optional fn_result
 """)
+        , test "Multiply used type variable in record only appears once in signature" <|
+            \_ ->
+                declarationAs
+                    (Elm.alias "Record"
+                        (Type.record
+                            [ ( "a", Type.var "var" )
+                            , ( "b", Type.var "var" )
+                            ]
+                        )
+                    )
+                    "type alias Record var =\n    { a : var, b : var }"
         ]
 
 


### PR DESCRIPTION
When declaring a type alias with a type variable which is used more then once, this variable will be duplicated in the signature. I moved the `unique` call into the `getGenerics` function so it is also applied when called in `Elm.alias`.