### PR TITLE
Fix dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,17 @@
 {
   "name": "elm-codegen",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "elm-codegen",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@types/node": "^15.0.3",
         "chalk": "^4.1.1",
         "chokidar": "^3.5.1",
         "commander": "^8.3.0",
-        "elm-optimize-level-2": "^0.1.5",
         "node-elm-compiler": "^5.0.6",
         "node-fetch": "^2.6.1"
       },
@@ -21,6 +19,7 @@
         "elm-codegen": "bin/elm-codegen"
       },
       "devDependencies": {
+        "@types/node": "^15.0.3",
         "@types/node-fetch": "^2.5.10",
         "ts-node": "^10.9.1",
         "typescript": "^4.2.4"
@@ -81,6 +80,7 @@
     },
     "node_modules/@types/node": {
       "version": "15.3.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node-fetch": {
@@ -281,55 +281,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "node_modules/elm-optimize-level-2": {
-      "version": "0.1.5",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "commander": "^6.0.0",
-        "node-elm-compiler": "^5.0.4",
-        "ts-union": "^2.2.1",
-        "typescript": "^3.9.7"
-      },
-      "bin": {
-        "elm-optimize-level-2": "bin/elm-optimize-level-2.js"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/elm-optimize-level-2/node_modules/chalk": {
-      "version": "4.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/elm-optimize-level-2/node_modules/commander": {
-      "version": "6.2.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/elm-optimize-level-2/node_modules/typescript": {
-      "version": "3.9.10",
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "node_modules/fill-range": {
@@ -725,10 +676,6 @@
         }
       }
     },
-    "node_modules/ts-union": {
-      "version": "2.3.0",
-      "license": "MIT"
-    },
     "node_modules/typescript": {
       "version": "4.2.4",
       "dev": true,
@@ -824,7 +771,8 @@
       "dev": true
     },
     "@types/node": {
-      "version": "15.3.1"
+      "version": "15.3.1",
+      "dev": true
     },
     "@types/node-fetch": {
       "version": "2.5.12",
@@ -951,31 +899,6 @@
     "diff": {
       "version": "4.0.2",
       "dev": true
-    },
-    "elm-optimize-level-2": {
-      "version": "0.1.5",
-      "requires": {
-        "chalk": "^4.1.0",
-        "commander": "^6.0.0",
-        "node-elm-compiler": "^5.0.4",
-        "ts-union": "^2.2.1",
-        "typescript": "^3.9.7"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "4.1.2",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "commander": {
-          "version": "6.2.1"
-        },
-        "typescript": {
-          "version": "3.9.10"
-        }
-      }
     },
     "fill-range": {
       "version": "7.0.1",
@@ -1199,9 +1122,6 @@
         "v8-compile-cache-lib": "^3.0.1",
         "yn": "3.1.1"
       }
-    },
-    "ts-union": {
-      "version": "2.3.0"
     },
     "typescript": {
       "version": "4.2.4",

--- a/package.json
+++ b/package.json
@@ -48,16 +48,15 @@
   },
   "homepage": "https://github.com/mdgriffith/elm-codegen#readme",
   "devDependencies": {
+    "@types/node": "^15.0.3",
     "@types/node-fetch": "^2.5.10",
     "ts-node": "^10.9.1",
     "typescript": "^4.2.4"
   },
   "dependencies": {
-    "@types/node": "^15.0.3",
     "chalk": "^4.1.1",
     "chokidar": "^3.5.1",
     "commander": "^8.3.0",
-    "elm-optimize-level-2": "^0.1.5",
     "node-elm-compiler": "^5.0.6",
     "node-fetch": "^2.6.1"
   }


### PR DESCRIPTION
- Remove `elm-optimize-level-2` which does not appear to be used. Reduces
  the install size with 50+ MB.
- Move `@types/node` to devDependencies, since elm-codegen does not seem
  to ship any TypeScript declarations that need it. Saves around ~1 MB.