### PR TITLE
Replace node-fetch with the Node.js https module

### DIFF
--- a/cli/run.ts
+++ b/cli/run.ts
@@ -45,8 +45,12 @@ async function httpsGetJson(url: string): Promise<any> {
         })
 
         res.on("end", () => {
-          const body = Buffer.concat(chunks)
-          resolve(JSON.parse(body.toString()))
+          const body = Buffer.concat(chunks).toString()
+          if (res.statusCode === 200) {
+            resolve(JSON.parse(body))
+          } else {
+            reject(new Error(`GET ${url} – expected status code 200 but got ${res.statusCode}:\n\n${body}`))
+          }
         })
       })
       .on("error", reject)

--- a/cli/run.ts
+++ b/cli/run.ts
@@ -19,11 +19,11 @@
 */
 
 import * as elm_compiler from "node-elm-compiler"
+import * as https from "https"
 import * as path from "path"
 import * as fs from "fs"
 import { XMLHttpRequest } from "./run/vendor/XMLHttpRequest"
 import * as Chokidar from "chokidar"
-import fetch from "node-fetch"
 import chalk from "chalk"
 import templates from "./templates"
 const gen_package = require("./gen-package")
@@ -33,6 +33,25 @@ const gen_package = require("./gen-package")
 globalThis["XMLHttpRequest"] = XMLHttpRequest.XMLHttpRequest
 
 const currentVersion = require("../package.json").version
+
+async function httpsGetJson(url: string): Promise<any> {
+  return new Promise((resolve, reject) => {
+    https
+      .get(url, (res) => {
+        const chunks: Buffer[] = []
+
+        res.on("data", (chunk: Buffer) => {
+          chunks.push(chunk)
+        })
+
+        res.on("end", () => {
+          const body = Buffer.concat(chunks)
+          resolve(JSON.parse(body.toString()))
+        })
+      })
+      .on("error", reject)
+  })
+}
 
 async function run_generator(output_dir: string, moduleName: string, elm_source: string, flags: any) {
   eval(elm_source)
@@ -172,8 +191,7 @@ async function install_package(
   codeGenJson: CodeGenJson
 ): Promise<CodeGenJson> {
   if (version == null) {
-    const searchResp = await fetch("https://elm-package-cache-psi.vercel.app/search.json")
-    const search = await searchResp.json()
+    const search = await httpsGetJson("https://elm-package-cache-psi.vercel.app/search.json")
     for (let found of search) {
       if (found.name == pkg) {
         version = found.version
@@ -185,8 +203,7 @@ async function install_package(
       process.exit(1)
     }
   }
-  const docsResp = await fetch(`https://elm-package-cache-psi.vercel.app/packages/${pkg}/${version}/docs.json`)
-  const docs = await docsResp.json()
+  const docs = await httpsGetJson(`https://elm-package-cache-psi.vercel.app/packages/${pkg}/${version}/docs.json`)
 
   // let codeGenJson = getCodeGenJson(install_dir)
 

--- a/cli/run.ts
+++ b/cli/run.ts
@@ -47,7 +47,11 @@ async function httpsGetJson(url: string): Promise<any> {
         res.on("end", () => {
           const body = Buffer.concat(chunks).toString()
           if (res.statusCode === 200) {
-            resolve(JSON.parse(body))
+            try {
+              resolve(JSON.parse(body))
+            } catch (error) {
+              reject(error)
+            }
           } else {
             reject(new Error(`GET ${url} – expected status code 200 but got ${res.statusCode}:\n\n${body}`))
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elm-codegen",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "elm-codegen",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/node": "^15.0.3",
@@ -14,8 +14,7 @@
         "chokidar": "^3.5.1",
         "commander": "^8.3.0",
         "elm-optimize-level-2": "^0.1.5",
-        "node-elm-compiler": "^5.0.6",
-        "node-fetch": "^2.6.1"
+        "node-elm-compiler": "^5.0.6"
       },
       "bin": {
         "elm-codegen": "bin/elm-codegen"
@@ -546,25 +545,6 @@
         "node": ">=4.0.0"
       }
     },
-    "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "license": "MIT",
@@ -678,11 +658,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
     "node_modules/ts-node": {
       "version": "10.9.1",
       "dev": true,
@@ -745,20 +720,6 @@
       "version": "3.0.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "node_modules/which": {
       "version": "1.3.1",
@@ -1107,14 +1068,6 @@
         "temp": "^0.9.0"
       }
     },
-    "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "requires": {
-        "whatwg-url": "^5.0.0"
-      }
-    },
     "normalize-path": {
       "version": "3.0.0"
     },
@@ -1176,11 +1129,6 @@
         "is-number": "^7.0.0"
       }
     },
-    "tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
     "ts-node": {
       "version": "10.9.1",
       "dev": true,
@@ -1210,20 +1158,6 @@
     "v8-compile-cache-lib": {
       "version": "3.0.1",
       "dev": true
-    },
-    "webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "requires": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "chokidar": "^3.5.1",
     "commander": "^8.3.0",
     "elm-optimize-level-2": "^0.1.5",
-    "node-elm-compiler": "^5.0.6",
-    "node-fetch": "^2.6.1"
+    "node-elm-compiler": "^5.0.6"
   }
 }


### PR DESCRIPTION
The uses of node-fetch were so few and trivial that I took a shot at getting rid of one more dependency!

Notes:

- node-fetch automatically sets these headers by default:

  ```
  accept: */*
  accept-encoding: gzip,deflate
  host: <the host in question>
  user-agent: node-fetch/1.0 (+https://github.com/bitinn/node-fetch)
  ```

  While `https.get` by default only sets `host`. Tested using https://hookbin.com/.

  We make requests to https://elm-package-cache-psi.vercel.app, and it does not seem to care about `accept` and `user-agent`. When sending `accept-encoding`, it does not respond with a `content-encoding`.

  So we don’t need to set any headers.

- node-fetch automatically follows redirects, while `https.get` does not. We’re not encountering any redirects though.

- The old code using node-fetch did not check for status codes. The new code does. So if the server is down you now get a nicer error than a JSON parse syntax error.