### PR TITLE
Assume user is not overloading the Elm name in imports

### DIFF
--- a/src/Elm/Op.elm
+++ b/src/Elm/Op.elm
@@ -84,11 +84,11 @@ import Set
 
 
        one
-           |> Elm.or two
-           |> Elm.or three
+           |> Elm.Op.or two
+           |> Elm.Op.or three
 
 
-       Elm.or one two
+       Elm.Op.or one two
 
 
 
@@ -424,8 +424,8 @@ query =
 {-| `|>`
 
     Elm.value "thang"
-        |> Elm.pipe (Elm.value "thang2")
-        |> Elm.pipe (Elm.value "thang3")
+        |> Elm.Op.pipe (Elm.value "thang2")
+        |> Elm.Op.pipe (Elm.value "thang3")
 
 Results in
 


### PR DESCRIPTION
I think it's more likely that users will import as:
```
import Elm
import Elm.Op
```
than as 
```
import Elm
import Elm.Op as Elm
```

so I think the examples in the docs should probably reflect this. Unless you're expecting folks to alias the imports?