### PR TITLE
Add missing exposed type.

### DIFF
--- a/src/Elm/Let.elm
+++ b/src/Elm/Let.elm
@@ -1,15 +1,14 @@
 module Elm.Let exposing
-    ( letIn, value
+    ( letIn, value, Let
     , tuple
     , record
     , fn, fn2, fn3
     , toExpression
-    , Let
     )
 
 {-| This module is for building `let` expressions.
 
-@docs letIn, value
+@docs letIn, value, Let
 
 Here's a brief example to get you started
 


### PR DESCRIPTION
In the `main` branch at e4fe72f I was getting this error when I ran the test script (`npm test`):

```
-- DOCS MISTAKE ------------------------------------------------ src/Elm/Let.elm

I do not see `Let` in your module documentation, but it is in your `exposing`
list:

7|     , Let
         ^^^
Add a line like `@docs Let` to your module documentation!

Note: See <https://elm-lang.org/0.19.1/docs> for more guidance on writing high
quality docs.
```

This exposes the `Let` type to fix that error.