### PR TITLE
Fix typo in docs

### DIFF
--- a/guide/UsingHelpers.md
+++ b/guide/UsingHelpers.md
@@ -146,7 +146,7 @@ If you take a peek in `elm.codegen.json`, you'll see something like this.
 }
 ```
 
-Notce the `local` field. If you want to generate bindings for other directories, either modify the file or run `elm-codegen install my/dir/`.
+Notice the `local` field? If you want to generate bindings for other directories, either modify the file or run `elm-codegen install my/dir/`.
 
 Then, when you run `elm-codegen install`, bindings will be generated for all files within those directories!
 


### PR DESCRIPTION
I changed `Notce` to `Notice` and made the sentence a question.