### PR TITLE
Expose Gen.CodeGen.Generate.directoryDecoder

### DIFF
--- a/cli/gen-package/codegen/Gen/CodeGen/Generate.elm
+++ b/cli/gen-package/codegen/Gen/CodeGen/Generate.elm
@@ -1,5 +1,5 @@
 port module Gen.CodeGen.Generate exposing
-    ( run, fromJson, fromText, fromDirectory
+    ( run, fromJson, fromText, fromDirectory, directoryDecoder
     , withFeedback, Error
     , File, Directory(..)
     , error, files, info
@@ -10,7 +10,7 @@ port module Gen.CodeGen.Generate exposing
 
 # Simple API
 
-@docs run, fromJson, fromText, fromDirectory
+@docs run, fromJson, fromText, fromDirectory, directoryDecoder
 
 
 # With errors

--- a/cli/templates/CodeGen.Generate.elm.ts
+++ b/cli/templates/CodeGen.Generate.elm.ts
@@ -1,7 +1,7 @@
 export default () =>
   `
 port module Gen.CodeGen.Generate exposing
-    ( run, fromJson, fromText, fromDirectory
+    ( run, fromJson, fromText, fromDirectory, directoryDecoder
     , withFeedback, Error
     , File, Directory(..)
     , error, files, info
@@ -12,7 +12,7 @@ port module Gen.CodeGen.Generate exposing
 
 # Simple API
 
-@docs run, fromJson, fromText, fromDirectory
+@docs run, fromJson, fromText, fromDirectory, directoryDecoder
 
 
 # With errors


### PR DESCRIPTION
When one wants to customize the behavior, it's handy to just reuse the existing `directoryDecoder`