### PR TITLE
Allow sandboxed builds to succeed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,9 @@
       },
       "engines": {
         "node": ">=12"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.0",
@@ -44,12 +46,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.9",
@@ -58,7 +64,9 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
@@ -87,22 +95,30 @@
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.3",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
     },
     "node_modules/@types/cacheable-request": {
       "version": "6.0.2",
@@ -134,7 +150,9 @@
     "node_modules/@types/node": {
       "version": "15.3.1",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.3.1.tgz",
+      "integrity": "sha512-weaeiP4UF4XgF++3rpQhpIJWsCTS4QJw5gvBhQu6cFIxTwyxWIe3xbnrY/o2lTCQ0lsdb8YIUDUvLR4Vuz5rbw=="
     },
     "node_modules/@types/node-fetch": {
       "version": "2.5.12",
@@ -143,12 +161,16 @@
       "dependencies": {
         "@types/node": "*",
         "form-data": "^3.0.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.12.tgz",
+      "integrity": "sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw=="
     },
     "node_modules/@types/node-fetch/node_modules/@types/node": {
       "version": "16.7.9",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.9.tgz",
+      "integrity": "sha512-KktxVzS4FPDFVHUUOWyZMvRo//8vqOLITtLMhFSW9IdLsYT/sPyXj3wXtaTcR7A7olCe7R2Xy7R+q5pg2bU46g=="
     },
     "node_modules/@types/responselike": {
       "version": "1.0.0",
@@ -168,7 +190,9 @@
       },
       "engines": {
         "node": ">=0.4.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w=="
     },
     "node_modules/acorn-walk": {
       "version": "8.2.0",
@@ -176,7 +200,9 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
     },
     "node_modules/ajv": {
       "version": "6.12.6",
@@ -229,7 +255,9 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="
     },
     "node_modules/anymatch": {
       "version": "3.1.2",
@@ -240,12 +268,16 @@
       },
       "engines": {
         "node": ">= 8"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg=="
     },
     "node_modules/arg": {
       "version": "4.1.3",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
     },
     "node_modules/asn1": {
       "version": "0.2.6",
@@ -268,7 +300,9 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -296,7 +330,9 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "license": "MIT"
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -332,7 +368,9 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
     },
     "node_modules/bl": {
       "version": "4.1.0",
@@ -351,7 +389,9 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA=="
     },
     "node_modules/braces": {
       "version": "3.0.2",
@@ -361,7 +401,9 @@
       },
       "engines": {
         "node": ">=8"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A=="
     },
     "node_modules/buffer": {
       "version": "5.7.1",
@@ -514,11 +556,15 @@
       },
       "engines": {
         "node": ">=7.0.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "license": "MIT"
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -529,18 +575,24 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="
     },
     "node_modules/commander": {
       "version": "8.3.0",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "license": "MIT"
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
@@ -551,7 +603,9 @@
     "node_modules/create-require": {
       "version": "1.1.1",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
     },
     "node_modules/cross-spawn": {
       "version": "6.0.5",
@@ -565,7 +619,9 @@
       },
       "engines": {
         "node": ">=4.8"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ=="
     },
     "node_modules/dashdash": {
       "version": "1.14.1",
@@ -647,7 +703,9 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "node_modules/diff": {
       "version": "4.0.2",
@@ -655,7 +713,9 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
     },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
@@ -993,7 +1053,9 @@
       },
       "engines": {
         "node": ">=8"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ=="
     },
     "node_modules/find-elm-dependencies": {
       "version": "2.0.4",
@@ -1007,7 +1069,9 @@
       },
       "engines": {
         "node": ">=4.0.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/find-elm-dependencies/-/find-elm-dependencies-2.0.4.tgz",
+      "integrity": "sha512-x/4w4fVmlD2X4PD9oQ+yh9EyaQef6OtEULdMGBTuWx0Nkppvo2Z/bAiQioW2n+GdRYKypME2b9OmYTw5tw5qDg=="
     },
     "node_modules/find-up": {
       "version": "4.1.0",
@@ -1027,7 +1091,9 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.4.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/firstline/-/firstline-1.3.1.tgz",
+      "integrity": "sha512-ycwgqtoxujz1dm0kjkBFOPQMESxB9uKc/PlD951dQDIG+tBXRpYZC2UmJb0gDxopQ1ZX6oyRQN3goRczYu7Deg=="
     },
     "node_modules/folder-hash": {
       "version": "3.3.3",
@@ -1066,7 +1132,9 @@
       },
       "engines": {
         "node": ">= 6"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg=="
     },
     "node_modules/fs-extra": {
       "version": "9.1.0",
@@ -1085,7 +1153,9 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
-      "license": "ISC"
+      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -1096,7 +1166,9 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="
     },
     "node_modules/get-stream": {
       "version": "5.2.0",
@@ -1138,7 +1210,9 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ=="
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
@@ -1148,7 +1222,9 @@
       },
       "engines": {
         "node": ">= 6"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="
     },
     "node_modules/got": {
       "version": "11.8.5",
@@ -1209,7 +1285,9 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
     "node_modules/http-cache-semantics": {
       "version": "4.1.0",
@@ -1271,11 +1349,15 @@
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "license": "ISC"
+      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -1285,14 +1367,18 @@
       },
       "engines": {
         "node": ">=8"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw=="
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -1311,7 +1397,9 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg=="
     },
     "node_modules/is-interactive": {
       "version": "1.0.0",
@@ -1327,7 +1415,9 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
@@ -1349,7 +1439,9 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "license": "ISC"
+      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/isstream": {
       "version": "0.1.2",
@@ -1446,7 +1538,9 @@
     },
     "node_modules/lodash": {
       "version": "4.17.21",
-      "license": "MIT"
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -1476,7 +1570,9 @@
     "node_modules/make-error": {
       "version": "1.3.6",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "node_modules/mime-db": {
       "version": "1.49.0",
@@ -1484,7 +1580,9 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.49.0.tgz",
+      "integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA=="
     },
     "node_modules/mime-types": {
       "version": "2.1.32",
@@ -1495,7 +1593,9 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.32.tgz",
+      "integrity": "sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A=="
     },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
@@ -1523,7 +1623,9 @@
       },
       "engines": {
         "node": "*"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
     },
     "node_modules/minimist": {
       "version": "1.2.6",
@@ -1538,7 +1640,9 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ=="
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -1548,7 +1652,9 @@
     },
     "node_modules/nice-try": {
       "version": "1.0.5",
-      "license": "MIT"
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "node_modules/node-elm-compiler": {
       "version": "5.0.6",
@@ -1561,14 +1667,18 @@
       },
       "engines": {
         "node": ">=4.0.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/node-elm-compiler/-/node-elm-compiler-5.0.6.tgz",
+      "integrity": "sha512-DWTRQR8b54rvschcZRREdsz7K84lnS8A6YJu8du3QLQ8f204SJbyTaA6NzYYbfUG97OTRKRv/0KZl82cTfpLhA=="
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
     "node_modules/normalize-url": {
       "version": "6.1.0",
@@ -1596,7 +1706,9 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="
     },
     "node_modules/onetime": {
       "version": "5.1.2",
@@ -1695,14 +1807,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
     },
     "node_modules/path-key": {
       "version": "2.0.1",
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw=="
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
@@ -1718,7 +1834,9 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
+      "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg=="
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -1889,7 +2007,9 @@
       },
       "bin": {
         "rimraf": "bin.js"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA=="
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -1922,7 +2042,9 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "node_modules/shebang-command": {
       "version": "1.2.0",
@@ -1932,14 +2054,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg=="
     },
     "node_modules/shebang-regex": {
       "version": "1.0.0",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ=="
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
@@ -2033,7 +2159,9 @@
       },
       "engines": {
         "node": ">=8"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="
     },
     "node_modules/supports-hyperlinks": {
       "version": "2.3.0",
@@ -2057,7 +2185,9 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
+      "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA=="
     },
     "node_modules/terminal-link": {
       "version": "2.1.1",
@@ -2089,7 +2219,9 @@
       },
       "engines": {
         "node": ">=8.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="
     },
     "node_modules/tough-cookie": {
       "version": "2.5.0",
@@ -2144,7 +2276,9 @@
         "@swc/wasm": {
           "optional": true
         }
-      }
+      },
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw=="
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -2186,7 +2320,9 @@
       },
       "engines": {
         "node": ">=4.2.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg=="
     },
     "node_modules/universalify": {
       "version": "2.0.0",
@@ -2225,7 +2361,9 @@
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
     },
     "node_modules/verror": {
       "version": "1.10.0",
@@ -2258,7 +2396,9 @@
       },
       "bin": {
         "which": "bin/which"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ=="
     },
     "node_modules/wrap-ansi": {
       "version": "6.2.0",
@@ -2276,7 +2416,9 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "license": "ISC"
+      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",
@@ -2293,7 +2435,9 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
     }
   },
   "dependencies": {


### PR DESCRIPTION
# Problem

elm-codegen cannot be built as-is in a sandboxed environment such as Nix.
The npm dependencies with no hash listed may be nondeterministic, which is disallowed in reproducible builds.

There are workarounds, such as applying this patch in the Nix build process, but I'd like to upstream this patch to share it with other elm-codegen users, and to lock down the dependency versions for all npm users.

# Solution

Use [jeslie0/npm-lockfile-fix] to fill in the missing hashes.

[jeslie0/npm-lockfile-fix]: https://github.com/jeslie0/npm-lockfile-fix
