### PR TITLE
Add Op namespace to plus operator in docs

### DIFF
--- a/src/Elm.elm
+++ b/src/Elm.elm
@@ -322,7 +322,11 @@ value details =
 
     import Elm.Annotation as Type
 
-    Elm.value "myString"
+    Elm.value
+        { importFrom = []
+        , name = "myString"
+        , annotation = Nothing
+        }
         |> Elm.withType Type.string
 
 Though be sure `elm-codegen` isn't already doing this automatically for you!
@@ -1439,7 +1443,7 @@ So, this
 
     Elm.fn ( "firstInt", Nothing )
         (\firstArgument ->
-            Elm.plus
+            Elm.Op.plus
                 (Elm.int 42)
                 firstArgument
         )
@@ -1453,7 +1457,7 @@ If you want to generate a **top level** function instead of an anonymous functio
     Elm.declaration "add42" <|
         Elm.fn ( "firstInt", Nothing )
             (\firstArgument ->
-                Elm.plus
+                Elm.Op.plus
                     (Elm.int 42)
                     firstArgument
             )

--- a/src/Elm/Op.elm
+++ b/src/Elm/Op.elm
@@ -427,7 +427,11 @@ query =
 
 {-| `|>`
 
-    Elm.value "thang"
+    Elm.value
+        { importFrom = []
+        , name = "thang"
+        , annotation = Nothing
+        }
         |> Elm.Op.pipe (Elm.value "thang2")
         |> Elm.Op.pipe (Elm.value "thang3")
 


### PR DESCRIPTION
Fix some doc comment examples.

plus : Lives in the `Elm.Op`
value : Had incorrect parameters in examples.

I got a bit stumped with these :)