### PR TITLE
Separate top level explicit exposes by lines [CLI v4.2.2] [Elm v0.5.4]

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "mdgriffith/elm-codegen",
     "summary": "A code generation library for Elm",
     "license": "BSD-3-Clause",
-    "version": "4.2.1",
+    "version": "4.2.2",
     "exposed-modules": [
         "Elm",
         "Elm.Op",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-codegen",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Codegen for Elm",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/Internal/Write.elm
+++ b/src/Internal/Write.elm
@@ -354,8 +354,23 @@ prettyExposing exposing_ =
 
 prettyTopLevelExposes : List TopLevelExpose -> Doc t
 prettyTopLevelExposes exposes =
-    List.map prettyTopLevelExpose exposes
-        |> Pretty.join (Pretty.string ", ")
+    let
+        renderedTopLevelExposes =
+            List.map prettyTopLevelExpose exposes
+
+        renderedWithSeparator =
+            case List.reverse renderedTopLevelExposes of
+                head :: tail ->
+                    head
+                        :: List.map (Pretty.a <| Pretty.char ',') tail
+                        |> List.reverse
+
+                _ ->
+                    renderedTopLevelExposes
+    in
+    renderedWithSeparator
+        |> Pretty.softlines
+        |> Pretty.nest 4
 
 
 prettyTopLevelExpose : TopLevelExpose -> Doc t


### PR DESCRIPTION
Once the number of input types grows to a point where concatenating them with a comma and a space causes the line to exceed `65535` characters, elm will fail to parse the file.

This change uses `softlines` from the `elm-pretty-printer` package to break up the exposes list as needed, but it prefers one line if possible. 