### PR TITLE
Fix number type variable collision in arithmetic operators

### DIFF
--- a/src/Elm/Op.elm
+++ b/src/Elm/Op.elm
@@ -589,37 +589,40 @@ applyNumber symbol dir l r =
                     Index.protectTypeName
                         "number"
                         annotationIndex
+
+                annotation : Result (List Compiler.InferenceError) Compiler.Inference
+                annotation =
+                    Compiler.applyType index
+                        (Ok
+                            { inferences = Dict.empty
+                            , aliases = Compiler.emptyAliases
+                            , type_ =
+                                Annotation.FunctionTypeAnnotation
+                                    (Compiler.nodify
+                                        (Annotation.GenericType numberTypeName)
+                                    )
+                                    (Compiler.nodify
+                                        (Annotation.FunctionTypeAnnotation
+                                            (Compiler.nodify
+                                                (Annotation.GenericType numberTypeName)
+                                            )
+                                            (Compiler.nodify
+                                                (Annotation.GenericType numberTypeName)
+                                            )
+                                        )
+                                    )
+                            }
+                        )
+                        [ left
+                        , right
+                        ]
             in
             { expression =
                 Exp.OperatorApplication symbol
                     dir
                     (Compiler.nodify left.expression)
                     (Compiler.nodify right.expression)
-            , annotation =
-                Compiler.applyType index
-                    (Ok
-                        { inferences = Dict.empty
-                        , aliases = Compiler.emptyAliases
-                        , type_ =
-                            Annotation.FunctionTypeAnnotation
-                                (Compiler.nodify
-                                    (Annotation.GenericType numberTypeName)
-                                )
-                                (Compiler.nodify
-                                    (Annotation.FunctionTypeAnnotation
-                                        (Compiler.nodify
-                                            (Annotation.GenericType numberTypeName)
-                                        )
-                                        (Compiler.nodify
-                                            (Annotation.GenericType numberTypeName)
-                                        )
-                                    )
-                                )
-                        }
-                    )
-                    [ left
-                    , right
-                    ]
+            , annotation = annotation
             , imports = left.imports ++ right.imports
             }
 

--- a/src/Internal/Compiler.elm
+++ b/src/Internal/Compiler.elm
@@ -1485,12 +1485,94 @@ applyType index annotation args =
                             mergedArgs.inferences
                             fnAnnotation.type_
                             mergedArgs.types
+                            |> Result.map resolveInferenceType
 
                     Err err ->
                         Err err
 
             else
                 Err []
+
+
+{-| After type application, eagerly substitute any type variables in
+the result type that are already resolved in the inference cache.
+
+This prevents internal type variables (like "number" in arithmetic
+operators) from leaking into the cache where they could collide
+with identically-named variables from sibling expressions.
+-}
+resolveInferenceType : Inference -> Inference
+resolveInferenceType inf =
+    { inf
+        | type_ = substituteType inf.inferences inf.type_
+    }
+
+
+substituteType : VariableCache -> Annotation.TypeAnnotation -> Annotation.TypeAnnotation
+substituteType cache type_ =
+    case type_ of
+        Annotation.GenericType varName ->
+            case Dict.get varName cache of
+                Just resolved ->
+                    -- Only substitute if the resolved type is concrete
+                    -- (not another GenericType that could chain further)
+                    case resolved of
+                        Annotation.GenericType _ ->
+                            type_
+
+                        _ ->
+                            resolved
+
+                Nothing ->
+                    type_
+
+        Annotation.Typed name vars ->
+            Annotation.Typed name
+                (List.map
+                    (\(Node.Node range inner) ->
+                        Node.Node range (substituteType cache inner)
+                    )
+                    vars
+                )
+
+        Annotation.FunctionTypeAnnotation (Node.Node rangeOne one) (Node.Node rangeTwo two) ->
+            Annotation.FunctionTypeAnnotation
+                (Node.Node rangeOne (substituteType cache one))
+                (Node.Node rangeTwo (substituteType cache two))
+
+        Annotation.Tupled nodes ->
+            Annotation.Tupled
+                (List.map
+                    (\(Node.Node range inner) ->
+                        Node.Node range (substituteType cache inner)
+                    )
+                    nodes
+                )
+
+        Annotation.Record fields ->
+            Annotation.Record
+                (List.map
+                    (\(Node.Node fieldRange ( name, Node.Node typeRange fieldType )) ->
+                        Node.Node fieldRange
+                            ( name, Node.Node typeRange (substituteType cache fieldType) )
+                    )
+                    fields
+                )
+
+        Annotation.GenericRecord baseName (Node.Node recordRange fields) ->
+            Annotation.GenericRecord baseName
+                (Node.Node recordRange
+                    (List.map
+                        (\(Node.Node fieldRange ( name, Node.Node typeRange fieldType )) ->
+                            Node.Node fieldRange
+                                ( name, Node.Node typeRange (substituteType cache fieldType) )
+                        )
+                        fields
+                    )
+                )
+
+        Annotation.Unit ->
+            type_
 
 
 mergeArgInferences :

--- a/tests/TypeChecking.elm
+++ b/tests/TypeChecking.elm
@@ -4,6 +4,7 @@ import Elm
 import Elm.Annotation as Type
 import Elm.Arg as Arg
 import Elm.Case
+import Elm.Declare
 import Elm.Expect
 import Elm.Op
 import Elm.ToString
@@ -203,6 +204,86 @@ generatedCode =
                         """
                         type alias Record var =
                             { a : var, b : var }
+                        """
+        , test "Record with mixed Float and Int fields infers correct types" <|
+            \_ ->
+                Elm.declaration "myRecord"
+                    (Elm.record
+                        [ ( "alpha", Elm.Op.plus (Elm.int 1) (Elm.int 2) )
+                        , ( "beta", Elm.unit )
+                        , ( "gamma", Elm.Op.gt (Elm.int 3) (Elm.int 4) )
+                        , ( "delta", Elm.Op.minus (Elm.float 10.5) (Elm.float 3.2) )
+                        , ( "epsilon", Elm.Op.multiply (Elm.int 5) (Elm.int 6) )
+                        ]
+                    )
+                    |> Elm.Expect.declarationAs
+                        """
+                        myRecord :
+                            { alpha : Int, beta : (), gamma : Bool, delta : Float, epsilon : Int }
+                        myRecord =
+                            { alpha = 1 + 2
+                            , beta = ()
+                            , gamma = 3 > 4
+                            , delta = 10.5 - 3.2
+                            , epsilon = 5 * 6
+                            }
+                        """
+        , test "Tuple with Float and Int arithmetic infers correct types" <|
+            \_ ->
+                Elm.declaration "myTuple"
+                    (Elm.tuple
+                        (Elm.Op.plus (Elm.float 1.5) (Elm.float 2.5))
+                        (Elm.Op.plus (Elm.int 1) (Elm.int 2))
+                    )
+                    |> Elm.Expect.declarationAs
+                        """
+                        myTuple : ( Float, Int )
+                        myTuple =
+                            ( 1.5 + 2.5, 1 + 2 )
+                        """
+        , describe "Number type resolution doesn't disturb polymorphic variables"
+            [ test "Arithmetic on polymorphic arg resolves to concrete type" <|
+                \_ ->
+                    Elm.Declare.fn "addOne"
+                        (Arg.var "x")
+                        (\x -> Elm.Op.plus x (Elm.int 1))
+                        |> .declaration
+                        |> Elm.Expect.declarationAs
+                            """
+                            addOne : Int -> Int
+                            addOne x =
+                                x + 1
+                            """
+            , test "Float arithmetic next to polymorphic value in tuple" <|
+                \_ ->
+                    Elm.Declare.fn "mixedTuple"
+                        (Arg.var "x")
+                        (\x ->
+                            Elm.tuple
+                                (Elm.Op.plus (Elm.float 1.0) (Elm.float 2.0))
+                                x
+                        )
+                        |> .declaration
+                        |> Elm.Expect.declarationAs
+                            """
+                            mixedTuple : x -> ( Float, x )
+                            mixedTuple x =
+                                ( 1 + 2, x )
+                            """
+            ]
+        , test "Triple with mixed Float and Int infers correct types" <|
+            \_ ->
+                Elm.declaration "myTriple"
+                    (Elm.triple
+                        (Elm.Op.minus (Elm.float 10.5) (Elm.float 3.2))
+                        Elm.unit
+                        (Elm.Op.plus (Elm.int 1) (Elm.int 2))
+                    )
+                    |> Elm.Expect.declarationAs
+                        """
+                        myTriple : ( Float, (), Int )
+                        myTriple =
+                            ( 10.5 - 3.2, (), 1 + 2 )
                         """
         ]
 


### PR DESCRIPTION
When multiple arithmetic operators appeared within the same tuple or record, their internal `number` type variables could collide because `toExpressionDetails` reuses index values across siblings.

This eagerly resolves type variables in `applyType` after unification, so concrete types (Float, Int, etc.) are stored directly in the result instead of leaving `GenericType` references in the inference cache where they could be overwritten by siblings.

Before:
```elm
Elm.tuple
    (Elm.Op.plus (Elm.float 1.5) (Elm.float 2.5))
    (Elm.Op.plus (Elm.int 1) (Elm.int 2))
````
generated `( Int, Int )`

Now it correctly generates the type annotation `( Float, Int )`.