### PR TITLE
Parenthesize lambdas on left side of operators

### DIFF
--- a/src/Internal/Write.elm
+++ b/src/Internal/Write.elm
@@ -1060,12 +1060,18 @@ prettyOperatorApplication aliases indent symbol dir (Node _ exprl) (Node _ exprr
                 Right ->
                     ( prec + 1, prec )
 
+        -- Lambda expressions need explicit parentheses on either side
+        -- of operators. On the right: `a |> \x -> b` is ambiguous.
+        -- On the left: `\x -> x <| "hello"` absorbs <| into the body.
         ( left, breakLeft ) =
-            prettyExpressionInner aliases { precedence = lprec } indent exprl
+            case exprl of
+                LambdaExpression _ ->
+                    prettyExpressionInner aliases { precedence = lprec } indent exprl
+                        |> Tuple.mapFirst Pretty.parens
 
-        -- Lambda expressions on the right side of operators like |>
-        -- need explicit parentheses because `a |> \x -> b |> \y -> c`
-        -- is ambiguous — the second |> could be inside the lambda body.
+                _ ->
+                    prettyExpressionInner aliases { precedence = lprec } indent exprl
+
         ( right, breakRight ) =
             case exprr of
                 LambdaExpression _ ->

--- a/tests/OperatorPrecedence.elm
+++ b/tests/OperatorPrecedence.elm
@@ -133,4 +133,20 @@ pipes =
                         (Elm.fn (Elm.Arg.var "y") (\y -> y))
                     |> Elm.Expect.renderedAs
                         """"hello" |> (\\x -> x) |> (\\y -> y)"""
+        , test "pipeLeft with lambda is parenthesized" <|
+            \_ ->
+                Elm.Op.pipeLeft
+                    (Elm.fn (Elm.Arg.var "x") (\x -> x))
+                    (Elm.string "hello")
+                    |> Elm.Expect.renderedAs
+                        """(\\x -> x) <| "hello\""""
+        , test "pipeLeft with lambda applied to complex expression" <|
+            \_ ->
+                Elm.Op.pipeLeft
+                    (Elm.fn (Elm.Arg.var "x")
+                        (\x -> Elm.Op.append x (Elm.string "!"))
+                    )
+                    (Elm.string "hello")
+                    |> Elm.Expect.renderedAs
+                        """(\\x -> x ++ "!") <| "hello\""""
         ]


### PR DESCRIPTION
When a lambda appeared as the left operand of `<|`, it was rendered without parentheses:

```elm
\x -> x <| "hello"
```

Which is semantically different, it incorrectly results in this precedence when Elm parses it `\x -> (x <| "hello")`.

The fix extends the existing right-side lambda parenthesization from #132 to also handle the left side.