### PR TITLE
Fix aliasAs generating wrong type for the alias variable

### DIFF
--- a/src/Internal/Arg.elm
+++ b/src/Internal/Arg.elm
@@ -182,8 +182,20 @@ aliasAs aliasName (Arg toArgDetails) =
                 innerArgDetails =
                     toArgDetails index
 
-                ( aliasVal, _, _ ) =
-                    val innerArgDetails.index aliasName
+                -- The alias refers to the same value as the underlying
+                -- pattern, so it should have the same type. Use the
+                -- inner pattern's annotation (the record type, tuple
+                -- type, etc.) rather than creating a fresh type variable.
+                aliasVal : Compiler.Expression
+                aliasVal =
+                    Compiler.Expression <|
+                        \_ ->
+                            { expression =
+                                Exp.FunctionOrValue []
+                                    (Format.sanitize aliasName)
+                            , annotation = innerArgDetails.details.annotation
+                            , imports = []
+                            }
             in
             { details =
                 { imports = innerArgDetails.details.imports

--- a/tests/TypeChecking.elm
+++ b/tests/TypeChecking.elm
@@ -271,6 +271,26 @@ generatedCode =
                                 ( 1 + 2, x )
                             """
             ]
+        , describe "aliasAs pattern type"
+            [ test "aliasAs on record pattern uses the underlying record type" <|
+                \_ ->
+                    Elm.Declare.fn "describe"
+                        (Arg.record (\a b -> ( a, b ))
+                            |> Arg.field "name"
+                            |> Arg.field "age"
+                            |> Arg.aliasAs "person"
+                        )
+                        (\( ( name, _ ), person ) ->
+                            Elm.tuple name person
+                        )
+                        |> .declaration
+                        |> Elm.Expect.declarationAs
+                            """
+                            describe : { name : name, age : age } -> ( name, { name : name, age : age } )
+                            describe ({ name, age } as person) =
+                                ( name, person )
+                            """
+            ]
         , test "Triple with mixed Float and Int infers correct types" <|
             \_ ->
                 Elm.declaration "myTriple"


### PR DESCRIPTION
When using `Elm.Arg.aliasAs` on a record pattern, the alias variable was incorrectly using a fresh type variable instead of inheriting the underlying pattern's type.

For example, here's what this snippet generates:

```elm
Arg.record ... |> Arg.field "name" |> Arg.aliasAs "person"
```

Before:

```elm
{ name : name, age : age } -> ( name, person )
```
(`person` is wrong - should be the record type)


After:

```elm
{ name : name, age : age } -> ( name, { name : name, age : age } )
```

Root cause: aliasAs was calling `val` which creates a fresh `GenericType` for the alias name. The fix uses the inner pattern's annotation (the actual record/tuple/etc type) for the alias value.